### PR TITLE
Return true for successfully read/replace/delete operations

### DIFF
--- a/src/ServerSideMock.coffee
+++ b/src/ServerSideMock.coffee
@@ -63,6 +63,7 @@ module.exports = class ServerSideMock
         if @nextCollectionOperationQueued
           @_shiftNext()
           callback(@nextError, @nextResources, @nextHeaders)
+          return true;
         return @nextCollectionOperationQueued
 
       readDocuments: (@lastEntityLink, @lastOptions, callback) =>
@@ -73,6 +74,7 @@ module.exports = class ServerSideMock
         if @nextCollectionOperationQueued
           @_shiftNext()
           callback(@nextError, @nextResources, @nextHeaders)
+          return true;
         return @nextCollectionOperationQueued
 
       createDocument: (@lastEntityLink, @lastRow, @lastOptions, callback) =>
@@ -85,6 +87,7 @@ module.exports = class ServerSideMock
           if callback?
             @_shiftNext()
             callback(@nextError, @nextResources, @nextHeaders)
+            return true;
         return @nextCollectionOperationQueued
 
       readDocument: (@lastEntityLink, @lastOptions, callback) =>
@@ -95,6 +98,7 @@ module.exports = class ServerSideMock
         if @nextCollectionOperationQueued
           @_shiftNext()
           callback(@nextError, @nextResources, @nextHeaders)
+          return true;
         return @nextCollectionOperationQueued
 
       replaceDocument: (@lastEntityLink, @lastRow, @lastOptions, callback) =>
@@ -109,6 +113,7 @@ module.exports = class ServerSideMock
           if callback?
             @_shiftNext()
             callback(@nextError, @nextResources, @nextHeaders)
+            return true;            
         return @nextCollectionOperationQueued
 
       deleteDocument: (@lastEntityLink, @lastOptions, callback) =>
@@ -121,4 +126,5 @@ module.exports = class ServerSideMock
           if callback?
             @_shiftNext()
             callback(@nextError, @nextResources, @nextHeaders)
+            return true;
         return @nextCollectionOperationQueued


### PR DESCRIPTION
At the moment the code gets the @nextCollectionOperationQueued property from the ServerSideMock instance.  If it is (true), it does a callback, then returns @nextCollectionOperationQueued.

The problem is, the callback could could call another operation on the ServerSideMock, which will set @nextCollectionOperationQueued to (false). When the callback exists, the original operation will return the now modified @nextCollectionOperationQueued (false) value instead of the original (true) value
